### PR TITLE
Added soft-depency

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -8,6 +8,13 @@
 	"compatibility" : {
 		"min" : "1.4.0"
 	},
+	"softDepends" :
+	[
+		"abyss-town.new battle music",
+		"heroes3-extended-soundtrack.heroes-legacy-bonus",
+		"heroes3-extended-soundtrack.heroes-legacy-terrains",
+		"wake-of-gods.mainmenu"
+	],
 	"changelog" : {
 		"1.00" : [ "Initial release" ]
 	},


### PR DESCRIPTION
Added soft-depency to solve console warnings. Abyss town music, Extended Soundtrack Heroes Legacy Bonus+Terrains and WoG main menu are loaded first, then HQ Music